### PR TITLE
選手アプリの再接続を安定化し位置表示を改善

### DIFF
--- a/lib/models/position.dart
+++ b/lib/models/position.dart
@@ -1,13 +1,23 @@
+import 'package:bsam/models/position_source.dart';
+
 class Position {
   double? lat;
   double? lng;
   double? acc;
+  PositionSource? positionSource;
 
-  Position({this.lat, this.lng, this.acc});
+  Position({this.lat, this.lng, this.acc, this.positionSource});
 
   Position.fromJson(Map<String, dynamic> json) {
     lat = json['latitude'].toDouble();
     lng = json['longitude'].toDouble();
     acc = json['accuracy'].toDouble();
+    positionSource = PositionSource.fromJsonValue(json['position_source']);
+
+    if (positionSource == null && acc == 0.0) {
+      positionSource = PositionSource.manual;
+    }
   }
+
+  bool get isManual => positionSource == PositionSource.manual;
 }

--- a/lib/models/position_source.dart
+++ b/lib/models/position_source.dart
@@ -1,0 +1,22 @@
+enum PositionSource {
+  gps('gps'),
+  manual('manual');
+
+  const PositionSource(this.value);
+
+  final String value;
+
+  static PositionSource? fromJsonValue(Object? rawValue) {
+    if (rawValue is! String) {
+      return null;
+    }
+
+    for (final source in PositionSource.values) {
+      if (source.value == rawValue) {
+        return source;
+      }
+    }
+
+    return null;
+  }
+}

--- a/lib/pages/navi/navigating.dart
+++ b/lib/pages/navi/navigating.dart
@@ -38,6 +38,11 @@ class Navigating extends StatefulWidget {
 class _NavigatingState extends State<Navigating> {
   @override
   Widget build(BuildContext context) {
+    final accuracyText =
+        widget.accuracy > 0.0
+            ? '${widget.accuracy.toStringAsFixed(2)} m'
+            : '位置未取得';
+
     return Column(
       children: [
         CompassArea(compassDeg: widget.compassDeg),
@@ -82,7 +87,7 @@ class _NavigatingState extends State<Navigating> {
           '${widget.latitude.toStringAsFixed(6)} / ${widget.longitude.toStringAsFixed(6)}',
         ),
         Text('位置情報の精度', style: Theme.of(context).textTheme.displaySmall),
-        Text('${widget.accuracy.toStringAsFixed(2)} m'),
+        Text(accuracyText),
         Text(
           '端末の方角 / コンパスの方角',
           style: Theme.of(context).textTheme.displaySmall,

--- a/lib/pages/navi/page.dart
+++ b/lib/pages/navi/page.dart
@@ -61,6 +61,7 @@ class _Navi extends ConsumerState<Navi> {
   StreamSubscription<CompassEvent>? _compass;
   late WebSocketChannel _channel;
   bool _disposed = false;
+  bool _isConnected = false;
   int _reconnectAttempts = 0;
   Timer? _reconnectTimer;
   bool _isConnecting = false;
@@ -133,11 +134,7 @@ class _Navi extends ConsumerState<Navi> {
     }
 
     // WebSocketの接続を適切に閉じる
-    try {
-      _channel.sink.close(status.normalClosure);
-    } catch (e) {
-      debugPrint('Error closing WebSocket: $e');
-    }
+    _closeWsConnection();
 
     WakelockPlus.disable();
     super.dispose();
@@ -241,6 +238,8 @@ class _Navi extends ConsumerState<Navi> {
       return;
     }
 
+    _closeWsConnection();
+
     // サーバーURLの取得
     final serverUrl = ref.read(serverUrlProvider);
 
@@ -276,6 +275,7 @@ class _Navi extends ConsumerState<Navi> {
         uri,
         pingInterval: const Duration(seconds: 1),
       );
+      _isConnected = true;
 
       // WebSocketメッセージサービスの初期化
       messageService = WsMessageService(_channel);
@@ -284,6 +284,7 @@ class _Navi extends ConsumerState<Navi> {
         _readWsMsg,
         onDone: () {
           debugPrint('WebSocket connection closed');
+          _isConnected = false;
           _isConnecting = false;
           // ウィジェットがアクティブな状態でのみ再接続を試みる
           // これにより、画面遷移後の不要な再接続を防ぐ
@@ -297,6 +298,7 @@ class _Navi extends ConsumerState<Navi> {
         },
         onError: (error) {
           debugPrint('WebSocket error: $error');
+          _isConnected = false;
           _isConnecting = false;
           // エラーを非致命的に記録
           // ネットワークエラーでアプリがクラッシュすることを防ぐ
@@ -326,6 +328,7 @@ class _Navi extends ConsumerState<Navi> {
       }
     } catch (e) {
       _isConnecting = false;
+      _isConnected = false;
       debugPrint('WebSocket connection exception: $e');
       FirebaseCrashlytics.instance.recordError(
         e,
@@ -369,6 +372,17 @@ class _Navi extends ConsumerState<Navi> {
         _connectWs();
       }
     });
+  }
+
+  void _closeWsConnection() {
+    try {
+      if (_isConnected) {
+        _channel.sink.close(status.normalClosure);
+        _isConnected = false;
+      }
+    } catch (e) {
+      debugPrint('Error closing WebSocket: $e');
+    }
   }
 
   _readWsMsg(dynamic msg) {

--- a/lib/pages/navi/waiting.dart
+++ b/lib/pages/navi/waiting.dart
@@ -18,6 +18,8 @@ class Waiting extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final accuracyText = accuracy > 0.0 ? '$accuracy m' : '位置未取得';
+
     return Container(
       alignment: Alignment.center,
       padding: const EdgeInsets.only(right: 15, left: 15),
@@ -30,7 +32,7 @@ class Waiting extends StatelessWidget {
             '${latitude.toStringAsFixed(6)} / ${longitude.toStringAsFixed(6)}',
           ),
           Text('位置情報の精度', style: Theme.of(context).textTheme.displaySmall),
-          Text('$accuracy m'),
+          Text(accuracyText),
           Text(
             '端末の方角 / コンパスの方角',
             style: Theme.of(context).textTheme.displaySmall,

--- a/test/models/position_test.dart
+++ b/test/models/position_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bsam/models/position.dart';
+import 'package:bsam/models/position_source.dart';
+
+void main() {
+  test('prefers explicit manual position source', () {
+    final position = Position.fromJson({
+      'latitude': 34.0,
+      'longitude': 136.0,
+      'accuracy': 3.0,
+      'position_source': 'manual',
+    });
+
+    expect(position.positionSource, PositionSource.manual);
+    expect(position.isManual, isTrue);
+  });
+
+  test('falls back to legacy manual accuracy for marks', () {
+    final position = Position.fromJson({
+      'latitude': 34.0,
+      'longitude': 136.0,
+      'accuracy': 0.0,
+    });
+
+    expect(position.positionSource, PositionSource.manual);
+    expect(position.isManual, isTrue);
+  });
+
+  test('keeps gps source when provided', () {
+    final position = Position.fromJson({
+      'latitude': 34.0,
+      'longitude': 136.0,
+      'accuracy': 0.0,
+      'position_source': 'gps',
+    });
+
+    expect(position.positionSource, PositionSource.gps);
+    expect(position.isManual, isFalse);
+  });
+}


### PR DESCRIPTION
## 概要
選手アプリで WebSocket 再接続前に旧接続を閉じるようにし、
再接続時の重複セッション発生を抑制します。
あわせて、mark の `position_source` 対応と位置表示の整理を行います。

## 変更内容
- 再接続前に既存 WebSocket を close するよう修正
- mark の `position_source` を解釈するモデルを追加
- legacy 互換として mark に限り `accuracy == 0` を manual として解釈
- 精度 0 / 未初期化時の表示を `位置未取得` に変更
- model テストを追加

## 背景
再接続時に旧接続が残ることで、サーバ側で同一選手のセッションが重複し、
本部画面の案内表示が不安定になる要因がありました。
また、位置精度と manual 判定の意味が混在していたため、表示も整理しています。

## 確認
- `flutter test test/models/position_test.dart`